### PR TITLE
Return the original prompt to the user if someone else is using the bot

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -40,7 +40,7 @@ def generate_image(ack, client, say, body):
     
     try:
         if using_user is not None:
-            say(f"Please try again after <@{using_user}> finishes genrating.")
+            say(f"Failed to generate an image for for the prompt `{prompt}`. Please try again after <@{using_user}> finishes genrating.")
 
         else:
             if pipe is None:


### PR DESCRIPTION
現状、誰かがBotを利用中だとせっかく頑張って打ち込んだコマンドが虚空に消えてしまいます。
悲しいのでちゃんとそのケースを救ってあげたい。
ただ、処理Queueを作るとかを今から実装するのは厳しいので、せめてPromptをそのまま出力して、再度コピペできるようにしてみました。

@marisakamozz 🙏 